### PR TITLE
Improve ingress yaml

### DIFF
--- a/p2/configurations/ingress.yml
+++ b/p2/configurations/ingress.yml
@@ -6,36 +6,36 @@ metadata:
 spec:
   ingressClassName: nginx-webapp
   rules:
-  - host: app1.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: webapp1
-            port:
-              number: 80
+    - host: app1.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webapp1
+                port:
+                  number: 80
 
-  - host: app2.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: webapp2
-            port:
-              number: 80
+    - host: app2.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webapp2
+                port:
+                  number: 80
 
-  - host: app3.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: webapp3
-            port:
-              number: 80
+    - host: app3.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webapp3
+                port:
+                  number: 80
 ...


### PR DESCRIPTION
### Metadata.name

the name isn't the name of application but
the name of the "ingress service"

For example, in this example:
> https://kubernetes.io/docs/concepts/services-networking/ingress/#ingressclass-scope
```yaml
metadata:
  name: external-lb-1
```
The ingress service name is `external-lb-1` (lb: load balancer) but there isn't the app name in this field

### Remove duplicate

DRY

Should we keep duplicated information ?
Like this [example from `ingress-nginx`](https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/) 

### Yaml lint

Use [yamllint](https://github.com/adrienverge/yamllint) tool to get yaml error
